### PR TITLE
Fix code scanning alert no. 38: Use of a cryptographic algorithm with insufficient key size

### DIFF
--- a/source/src/main/java/com/bond/allianz/Dao/invoice.java
+++ b/source/src/main/java/com/bond/allianz/Dao/invoice.java
@@ -60,7 +60,7 @@ public  invoice(JdbcTemplate jd)
 
     public void testRSAGenerate() throws Exception {
         KeyPairGenerator keyPairGen = KeyPairGenerator.getInstance("RSA");
-        keyPairGen.initialize(1024);
+        keyPairGen.initialize(2048);
         KeyPair keyPair = keyPairGen.generateKeyPair();
         PublicKey publicKey = keyPair.getPublic();
         PrivateKey privateKey = keyPair.getPrivate();


### PR DESCRIPTION
Fixes [https://github.com/jiangyghz/allian/security/code-scanning/38](https://github.com/jiangyghz/allian/security/code-scanning/38)

To fix the problem, we need to increase the key size for the RSA encryption to at least 2048 bits. This change will ensure that the encryption is secure and resistant to brute-force attacks.

- **General Fix:** Increase the key size for RSA encryption to 2048 bits or more.
- **Detailed Fix:** Modify the `initialize` method call for the `KeyPairGenerator` instance to use a key size of 2048 bits instead of 1024 bits.
- **Specific Changes:** Update line 63 in the `testRSAGenerate` method to use a key size of 2048 bits.
- **Requirements:** No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
